### PR TITLE
Add compatibility for pixelated backgrounds

### DIFF
--- a/FancyLightingMod.cs
+++ b/FancyLightingMod.cs
@@ -523,11 +523,19 @@ public sealed class FancyLightingMod : Mod
                 );
         }
 
+        SamplerState samplerState;
+        if (ModLoader.TryGetMod("PixelatedBackgrounds", out Mod _))
+        {
+            samplerState = SamplerState.PointClamp;
+        } else {
+            samplerState = _inCameraMode ? SamplerState.AnisotropicClamp : SamplerState.LinearClamp;
+        }
+
         Main.spriteBatch.End();
         Main.spriteBatch.Begin(
             SpriteSortMode.Immediate,
             BlendState.AlphaBlend,
-            _inCameraMode ? SamplerState.AnisotropicClamp : SamplerState.LinearClamp,
+            samplerState,
             DepthStencilState.Default,
             RasterizerState.CullNone,
             null,


### PR DESCRIPTION
Would previously blur backgrounds anyway with overbright enabled (otherwise it early returns due to `DoGammaCorrection`)